### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 cp sample.config.json config.json
-pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 python main.py
 ```
 **Note**: Make sure the right config variables are set. If you don't set the variables for the Kollider API then it will not hedge.


### PR DESCRIPTION
Ensures that your python version is used with pip.
Was recommended on [stack overflow](https://stackoverflow.com/questions/51373063/pip3-bad-interpreter-no-such-file-or-directory) which resolved an installation issue I was having